### PR TITLE
Unify on `${CONTAINER_ENGINE}` usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ IMAGE?=registry.redhat.io/redhat/redhat-operator-index:v4.7
 #INDEX_DB_PATH_AND_NAME?=olm_catalog_indexes/index.db.4.6.community-operators
 INDEX_DB_PATH_AND_NAME?=olm_catalog_indexes/index.db.4.7.redhat-operators
 
+# To introduce efficiencies for pulling new images for the Red Hat index,
+# we can use the registry.redhat.io v2 api directly. Set these parameters
+# if you want to only update when something newer is out there
+REGISTRY_REDHAT_IO_USER?=NOTSET
+REGISTRY_REDHAT_IO_PASS?=NOTSET
+
 detected_OS := $(shell uname 2>/dev/null || echo Unknown)
 
 .PHONY: all
@@ -25,9 +31,15 @@ install:
 	go install
 
 get-index:
-	docker login registry.redhat.io && \
-	docker rmi $(IMAGE) | true
-	docker run --rm --entrypoint cat $(IMAGE) /database/index.db > \
+	$(CONTAINER_ENGINE) login registry.redhat.io
+ifneq ($(REGISTRY_REDHAT_IO_PASS),NOTSET)
+	@# Don't un-@ this next line as it will show the password in the log
+	@./get-index.sh $(CONTAINER_ENGINE) ${IMAGE} ${REGISTRY_REDHAT_IO_USER} ${REGISTRY_REDHAT_IO_PASS}
+else
+	@# If a user doesn't set the password, then let's just force a refresh
+	$(CONTAINER_ENGINE) rmi -f $(IMAGE) | true
+endif
+	$(CONTAINER_ENGINE) run --rm --entrypoint cat $(IMAGE) /database/index.db > \
 	$(INDEX_DB_PATH_AND_NAME)
 
 run: build
@@ -37,7 +49,7 @@ run: build
 	cp $(PWD)/$(MERMAID_TEMP_SCRIPT) /tmp/$(MERMAID_TEMP_SCRIPT)
 	touch /tmp/$(MERMAID_TEMP_SCRIPT).$(OUTPUT_TYPE)
 	chmod o+w /tmp/$(MERMAID_TEMP_SCRIPT).$(OUTPUT_TYPE)
-	$(CONTAINER_ENGINE) pull minlag/mermaid-cli
+	$(CONTAINER_ENGINE) pull docker.io/minlag/mermaid-cli
 	$(CONTAINER_ENGINE) run \
 		--privileged \
 		-v /tmp/$(MERMAID_TEMP_SCRIPT):/$(MERMAID_TEMP_SCRIPT) \

--- a/README.md
+++ b/README.md
@@ -1,21 +1,48 @@
 ## Output Mermaid graph script from Operator Lifecycle Manager indices
 
-### Required:
+### Dependencies
+#### Required
 - make
 - sqlite3 
 - go v14+ 
 - container execution environment (such as Docker, podman)
+#### Optional
+- jq (needed to intelligently delete current index only if outdated)
 
 ### Usage
 Setting `INDEX_DB_PATH_AND_NAME` controls the file pointed to in `sqlite3.sql`, this controls what index gets graphed.
 
-To get, possibly, more recent images:
+#### Get or refresh the index image
+You will need to have the index image locally so that you can extract the olm database from it.
+
+As it turns out, if you're not logged into two Red Hat registries you will silently be redirected to other images for the redhat-redhat indexes
+This repo comes with some recent downloads of the indexes that have been pulled after logging into these registries.
+You may want to recreate this process with the following command as a template:
+```bash
+docker login https://registry.connect.redhat.com
+docker login registry.redhat.io
+docker rmi --force registry.redhat.io/redhat/redhat-operator-index:v4.8
+docker run --rm --entrypoint cat registry.redhat.io/redhat/redhat-operator-index:v4.8 /database/index.db > olm_catalog_indexes/index.db.4.8.redhat-operators
+```
+Running the above would get the true latest index for OpenShift 4.8.
+
+If you want to get the latest image yourself, you can use the `get-index` Make target. This will force you to download the latest
+index image (and therefore latest database) present.
+
 ```bash
 INDEX_DB_PATH_AND_NAME=olm_catalog_indexes/index.db.4.7.redhat-operators
 IMAGE=registry.redhat.io/redhat/redhat-operator-index:v4.7 
 make get-index
 ```
 
+By default, this will always delete the `IMAGE` from your local system and will therefore always pull an image when run. If, however,
+you only want to delete your local image when a newer image is available for pulling you can set/pass credentials for `registry.redhat.io`.
+
+```bash
+make get-index REGISTRY_REDHAT_IO_USER=<username> REGISTRY_REDHAT_IO_PASS=<password> CONTAINER_ENGINE=podman 
+```
+
+#### Generating the graph
 Without setting `INDEX_DB_PATH_AND_NAME` just using the 4.7 index for Red Hat operators:
 ```bash
 make run <ARGS=operator-package-name>
@@ -34,19 +61,16 @@ Your Mermaid graph should open if `open` command opens the chosen graphic output
 If not, image file saved as `/tmp/mermaid.mer.png`<br>
 Mermaid script file will be `./mermaid.mer`
 
+If you are using `podman` instead of `docker` CLI, you can still leverage this script by exporting `CONTAINER_ENGINE`
+```bash
+export CONTAINER_ENGINE=podman
+```
+or just adding it to the parameters for each run:
+```bash
+CONTAINER_ENGINE=podman INDEX_DB_PATH_AND_NAME=olm_catalog_indexes/index.db.4.7.redhat-operators make run ARGS=jaeger-product
+```
+
 ### Note
 - First time usage of `make run` may be slow due to download of Mermaid Docker image.
 - tweak the makefile if you need other file output types than SVG
-
-### Note about index freshening
-
-Turns out, if you're not logged into two Red Hat registries you will silently be redirected to other images for the redhat-redhat indexes
-This repo comes with some recent downloads of the indexes that have been pulled after logging into these registries.
-You may want to recreate this process with the following command as a template:
-```bash
-docker login https://registry.connect.redhat.com
-docker login registry.redhat.io
-docker rmi --force registry.redhat.io/redhat/redhat-operator-index:v4.8
-docker run --rm --entrypoint cat registry.redhat.io/redhat/redhat-operator-index:v4.8 /database/index.db > olm_catalog_indexes/index.db.4.8.redhat-operators
-```
-Running the above would get the true latest index for OpenShift 4.8.
+- `podman` on OSX will not work by default as there is not native support for mounting volumes on the client host. A potential workaround can be found in [this issue](https://github.com/containers/podman/issues/8016#issuecomment-920015800)

--- a/get-index.sh
+++ b/get-index.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+get_index () {
+    REDHAT_REGISTRY_TOKEN=$(curl --silent -u "${REGISTRY_REDHAT_IO_USER}":${REGISTRY_REDHAT_IO_PASS} "https://sso.redhat.com/auth/realms/rhcc/protocol/redhat-docker-v2/auth?service=docker-registry&client_id=curl&scope=repository:rhel:pull" | jq -r '.access_token')
+    REMOTE_CREATED=$(curl --silent --location -H "Authorization: Bearer $REDHAT_REGISTRY_TOKEN"  https://registry.redhat.io/v2/redhat/redhat-operator-index/manifests/v4.8 | jq -r '.history[0].v1Compatibility' | jq -r '.created')
+    LOCAL_CREATED=$(podman inspect registry.redhat.io/redhat/redhat-operator-index:v4.8 | jq -r '.[0].Created')
+    if [ "${REMOTE_CREATED}" != "${LOCAL_CREATED}" ]; then
+        ${CONTAINER_ENGINE} rmi -f ${IMAGE} | true
+    fi
+}
+
+# Make sure all variables are set in the environment
+export CONTAINER_ENGINE=$1
+export IMAGE=$2
+export REGISTRY_REDHAT_IO_USER=$3
+export REGISTRY_REDHAT_IO_PASS=$4
+echo "Checking for and outdated ${IMAGE} against the registry with user ${REGISTRY_REDHAT_IO_USER}."
+
+get_index


### PR DESCRIPTION
Also force removal of previous `${IMAGE}` when possible to reduce
likelihood of stale index image usage

Signed-off-by: arewm <arewm@users.noreply.github.com>